### PR TITLE
Add URL to _pkgdown

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,7 +1,7 @@
 # FIXME: The url field needs to be updated to contain the URL of the website
 # where the package documentation is hosted
 # (e.g., https://epiverse-trace.github.io/pkg).
-url: ~
+url: https://epiverse-trace.github.io/datatagr
 template:
   package: epiversetheme
 


### PR DESCRIPTION
This PR adds the URL to the pkgdown configuration. This was an oversight in #4.