### PR TITLE
Remove `# nolint` for options

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -9,7 +9,8 @@ linters: all_linters(
       modify_defaults(
         default_undesirable_functions,
         citEntry = "use the more modern bibentry() function",
-        library = NULL # too many false positive in too many files
+        library = NULL, # too many false positive in too many files
+        options = NULL
       )
     ),
     function_argument_linter = NULL,

--- a/R/lost_tags_action.R
+++ b/R/lost_tags_action.R
@@ -43,11 +43,11 @@
 #'
 lost_tags_action <- function(action = c("warning", "error", "none"),
                              quiet = FALSE) {
-  datatagr_options <- options("datatagr")$datatagr # nolint
+  datatagr_options <- options("datatagr")$datatagr
 
   action <- match.arg(action)
   datatagr_options$lost_tags_action <- action
-  options(datatagr = datatagr_options) # nolint
+  options(datatagr = datatagr_options)
   if (!quiet) {
     if (action == "warning") msg <- "Lost tags will now issue a warning."
     if (action == "error") msg <- "Lost tags will now issue an error."
@@ -64,5 +64,5 @@ lost_tags_action <- function(action = c("warning", "error", "none"),
 #' @rdname lost_tags_action
 
 get_lost_tags_action <- function() {
-  options("datatagr")$datatagr$lost_tags_action # nolint
+  options("datatagr")$datatagr$lost_tags_action
 }


### PR DESCRIPTION
This PR removes the `# nolint` for the options modifications, by updating `.lintr` instead (as in [**linelist**](https://github.com/epiverse-trace/linelist/blob/9e49d071844626454eea9766f7eadaba12121907/.lintr#L13)).

Fixes #9.