### PR TITLE
Remove `allow_extra`

### DIFF
--- a/R/make_datatagr.R
+++ b/R/make_datatagr.R
@@ -14,10 +14,6 @@
 #' @param tag_defaults a list of default values for the provided tags. Defaults
 #'   to `list()`, effectively defaulting to NULL values.
 #'
-#' @param allow_extra a `logical` indicating if additional data tags not
-#'   currently recognized by `datatagr` should be allowed; if `FALSE`, unknown
-#'   tags will trigger an error
-#'
 #' @seealso
 #'
 #' * An overview of the [datatagr] package
@@ -55,12 +51,10 @@
 #'
 make_datatagr <- function(x,
                           ...,
-                          tag_defaults = list(),
-                          allow_extra = TRUE) {
+                          tag_defaults = list()) {
   # assert inputs
   checkmate::assert_data_frame(x, min.cols = 1)
   assert_not_data_table(x)
-  checkmate::assert_logical(allow_extra)
 
   args <- rlang::list2(...)
 

--- a/R/set_tags.R
+++ b/R/set_tags.R
@@ -30,10 +30,9 @@
 #' ## setting tags providing a list (used to restore old tags here)
 #' x <- set_tags(x, !!!old_tags)
 #' tags(x)
-set_tags <- function(x, ..., tag_defaults = list(), allow_extra = TRUE) {
+set_tags <- function(x, ..., tag_defaults = list()) {
   # assert inputs
   checkmate::assertClass(x, "datatagr")
-  checkmate::assertLogical(allow_extra)
 
   old_tags <- attr(x, "tags")
   defaults <- tag_defaults

--- a/R/tags_types.R
+++ b/R/tags_types.R
@@ -22,9 +22,9 @@
 #' tags_types(date_onset = "Date") # impose a Date class
 #'
 #' # add new types e.g. to allow genetic sequences using ape's format
-#' tags_types(sequence = "DNAbin", allow_extra = TRUE)
+#' tags_types(sequence = "DNAbin")
 #'
-tags_types <- function(..., allow_extra = TRUE) {
+tags_types <- function(...) {
   defaults <- list()
 
   new_values <- rlang::list2(...)

--- a/R/validate_tags.R
+++ b/R/validate_tags.R
@@ -2,8 +2,7 @@
 #'
 #' This function evaluates the validity of the tags of a `datatagr` object by
 #' checking that: i) tags are present ii) tags is a `list` of `character` iii)
-#' that all default tags are present iv) tagged variables exist v) that no extra
-#' tag exists (if `allow_extra` is `FALSE`).
+#' that all default tags are present iv) tagged variables exist.
 #'
 #' @export
 #'

--- a/man/make_datatagr.Rd
+++ b/man/make_datatagr.Rd
@@ -4,7 +4,7 @@
 \alias{make_datatagr}
 \title{Create a datatagr from a data.frame}
 \usage{
-make_datatagr(x, ..., tag_defaults = list(), allow_extra = TRUE)
+make_datatagr(x, ..., tag_defaults = list())
 }
 \arguments{
 \item{x}{a \code{data.frame} or a \code{tibble}}
@@ -15,10 +15,6 @@ make_datatagr(x, ..., tag_defaults = list(), allow_extra = TRUE)
 
 \item{tag_defaults}{a list of default values for the provided tags. Defaults
 to \code{list()}, effectively defaulting to NULL values.}
-
-\item{allow_extra}{a \code{logical} indicating if additional data tags not
-currently recognized by \code{datatagr} should be allowed; if \code{FALSE}, unknown
-tags will trigger an error}
 }
 \value{
 The function returns a \code{datatagr} object.

--- a/man/set_tags.Rd
+++ b/man/set_tags.Rd
@@ -4,7 +4,7 @@
 \alias{set_tags}
 \title{Changes tags of a datatagr object}
 \usage{
-set_tags(x, ..., tag_defaults = list(), allow_extra = TRUE)
+set_tags(x, ..., tag_defaults = list())
 }
 \arguments{
 \item{x}{a \code{data.frame} or a \code{tibble}}
@@ -15,10 +15,6 @@ set_tags(x, ..., tag_defaults = list(), allow_extra = TRUE)
 
 \item{tag_defaults}{a list of default values for the provided tags. Defaults
 to \code{list()}, effectively defaulting to NULL values.}
-
-\item{allow_extra}{a \code{logical} indicating if additional data tags not
-currently recognized by \code{datatagr} should be allowed; if \code{FALSE}, unknown
-tags will trigger an error}
 }
 \value{
 The function returns a \code{datatagr} object.

--- a/man/tags_types.Rd
+++ b/man/tags_types.Rd
@@ -4,16 +4,12 @@
 \alias{tags_types}
 \title{List acceptable variable types for tags}
 \usage{
-tags_types(..., allow_extra = TRUE)
+tags_types(...)
 }
 \arguments{
 \item{...}{<\code{\link[rlang:dyn-dots]{dynamic-dots}}> A series of tags provided as
 \code{tag_name = "column_name"}. When specifying tags, please also see
 \code{tag_defaults} to specify default values.}
-
-\item{allow_extra}{a \code{logical} indicating if additional data tags not
-currently recognized by \code{datatagr} should be allowed; if \code{FALSE}, unknown
-tags will trigger an error}
 }
 \value{
 A named \code{list}.
@@ -31,7 +27,7 @@ tags_types()
 tags_types(date_onset = "Date") # impose a Date class
 
 # add new types e.g. to allow genetic sequences using ape's format
-tags_types(sequence = "DNAbin", allow_extra = TRUE)
+tags_types(sequence = "DNAbin")
 
 }
 \seealso{

--- a/man/validate_tags.Rd
+++ b/man/validate_tags.Rd
@@ -15,8 +15,7 @@ If checks pass, a \code{datatagr} object; otherwise issues an error.
 \description{
 This function evaluates the validity of the tags of a \code{datatagr} object by
 checking that: i) tags are present ii) tags is a \code{list} of \code{character} iii)
-that all default tags are present iv) tagged variables exist v) that no extra
-tag exists (if \code{allow_extra} is \code{FALSE}).
+that all default tags are present iv) tagged variables exist.
 }
 \examples{
 if (require(dplyr) && require(magrittr)) {

--- a/tests/testthat/test-make_datatagr.R
+++ b/tests/testthat/test-make_datatagr.R
@@ -23,7 +23,7 @@ test_that("tests for make_datatagr", {
   expect_null(tags(x)$outcome)
   expect_null(tags(x)$date_reporting)
 
-  x <- make_datatagr(cars, foo = "speed", bar = "dist", allow_extra = TRUE)
+  x <- make_datatagr(cars, foo = "speed", bar = "dist")
   expect_identical(
     tags(x, TRUE),
     c(list(), foo = "speed", bar = "dist")

--- a/tests/testthat/test-prune_tags.R
+++ b/tests/testthat/test-prune_tags.R
@@ -24,7 +24,7 @@ test_that("prune_tags() doesn't error on a datatagr with extra tags", {
   # https://github.com/epiverse-trace/linelist/issues/63
 
   dat <- data.frame(a = 1)
-  ll <- make_datatagr(dat, a = "a", allow_extra = TRUE)
+  ll <- make_datatagr(dat, a = "a")
 
   expect_no_condition(ll["a"])
   expect_identical(ll, ll["a"])

--- a/tests/testthat/test-tags_types.R
+++ b/tests/testthat/test-tags_types.R
@@ -6,6 +6,6 @@ test_that("tests for tags_types", {
 
   x <- tags_types(date_outcome = "Date")
   expect_identical(x$date_outcome, "Date")
-  x <- tags_types(date_outcome = "Date", seq = "DNAbin", allow_extra = TRUE)
+  x <- tags_types(date_outcome = "Date", seq = "DNAbin")
   expect_identical(x$seq, "DNAbin")
 })

--- a/tests/testthat/test-validate_datatagr.R
+++ b/tests/testthat/test-validate_datatagr.R
@@ -3,7 +3,7 @@ test_that("tests for validate_datatagr", {
   msg <- "Must inherit from class 'datatagr', but has class 'NULL'."
   expect_error(validate_datatagr(NULL), msg)
 
-  x <- make_datatagr(cars, id = "speed", toto = "dist", allow_extra = TRUE)
+  x <- make_datatagr(cars, id = "speed", toto = "dist")
   msg <- "Allowed types for tag `id`, `toto` are not documented in `ref_types`."
   expect_error(validate_datatagr(x), msg)
   expect_identical(x, validate_datatagr(x, ref_types = list(id = "numeric", toto = "numeric")))

--- a/tests/testthat/test-validate_tags.R
+++ b/tests/testthat/test-validate_tags.R
@@ -28,6 +28,6 @@ test_that("tests for validate_tags", {
   x <- make_datatagr(cars)
   expect_identical(x, validate_tags(x))
 
-  x <- set_tags(x, date_onset = "dist", toto = "speed", allow_extra = TRUE)
+  x <- set_tags(x, date_onset = "dist", toto = "speed")
   expect_identical(x, validate_tags(x))
 })

--- a/tests/testthat/test-validate_types.R
+++ b/tests/testthat/test-validate_types.R
@@ -30,14 +30,14 @@ test_that("validate_types() validates types", {
 
 test_that("missing ref_type in validate_types()", {
   # Single missing
-  x <- make_datatagr(cars, mph = "speed", d = "dist", allow_extra = TRUE)
+  x <- make_datatagr(cars, mph = "speed", d = "dist")
   expect_error(
     validate_types(x),
     "Allowed types for tag `mph`, `d` are not documented in `ref_types`."
   )
 
   # Two missing
-  x <- make_datatagr(cars, a = "speed", d = "dist", allow_extra = TRUE)
+  x <- make_datatagr(cars, a = "speed", d = "dist")
   expect_error(
     validate_types(x),
     "Allowed types for tag `a`, `d` are not documented in `ref_types`."


### PR DESCRIPTION
This PR removes the `allow_extra` argument from all functions and tests. **datatagr** does not know about any defaults, so everything can be considered *extra*. **linelist** has defaults and will still have to deal with this functionality, but we don't have to do it here in **datatagr**.

Fixes #22.