### PR TITLE
Update `LINELIST_LOST_ACTION` variable name

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,3 @@
 .onLoad <- function(libname, pkgname) {
-  lost_tags_action(Sys.getenv("LINELIST_LOST_ACTION", "warning"), quiet = TRUE)
+  lost_tags_action(Sys.getenv("DATATAGR_LOST_ACTION", "warning"), quiet = TRUE)
 }

--- a/tests/testthat/test-zzz.R
+++ b/tests/testthat/test-zzz.R
@@ -18,7 +18,7 @@ test_that("Environment variable is used for initial `lost_tags_action`", {
       library(datatagr)
       get_lost_tags_action()
     },
-    env = c(LINELIST_LOST_ACTION = "error")
+    env = c(DATATAGR_LOST_ACTION = "error")
   )
   expect_identical(res, "error")
 })


### PR DESCRIPTION
This PR addresses the remnant variable name `LINELIST_LOST_ACTION` and changes it to `DATATAGR_LOST_ACTION`. I am not sure why it kept failing on my local device before, but this time it seemed to work. Fresh eyes do a lot 😊 

Fixes #12.