### PR TITLE
Update validation in accordance with linelist/pull/146

### DIFF
--- a/R/validate_datatagr.R
+++ b/R/validate_datatagr.R
@@ -59,5 +59,7 @@ validate_datatagr <- function(x,
   validate_tags(x)
   validate_types(x, ref_types)
 
-  x
+  message("'", checkmate::vname(x), "' is a valid datatagr object")
+  
+  invisible(x)
 }

--- a/tests/testthat/test-validate_datatagr.R
+++ b/tests/testthat/test-validate_datatagr.R
@@ -1,13 +1,13 @@
-test_that("tests for validate_datatagr", {
+test_that("validate_datatagr() detects invalid objects", {
   # errors
   msg <- "Must inherit from class 'datatagr', but has class 'NULL'."
   expect_error(validate_datatagr(NULL), msg)
-
+  
   x <- make_datatagr(cars, id = "speed", toto = "dist")
   msg <- "Allowed types for tag `id`, `toto` are not documented in `ref_types`."
   expect_error(validate_datatagr(x), msg)
   expect_identical(x, validate_datatagr(x, ref_types = list(id = "numeric", toto = "numeric")))
-
+  
   x <- make_datatagr(cars, gender = "speed")
   expect_error(
     validate_datatagr(x, ref_types = tags_types(gender = c(
@@ -16,8 +16,22 @@ test_that("tests for validate_datatagr", {
     ))),
     "- gender: Must inherit from class 'character'/'factor'"
   )
+})
 
-  # Functionalities
-  x <- make_datatagr(cars)
-  expect_identical(x, validate_datatagr(x))
+test_that("validate_datatagr() allows valid objects", {
+  x <- make_datatagr(cars, id = "speed")
+  
+  # Print a message
+  expect_message(
+    validate_datatagr(x, ref_types = list(id = "numeric")),
+    "valid"
+  )
+  
+  # And returns invisibly...
+  v <- suppressMessages(
+    expect_invisible(validate_datatagr(x, 
+                                       ref_types = list(id = "numeric"))))
+  
+  # ...an identical object
+  expect_identical(x, v)
 })


### PR DESCRIPTION
This PR updates the **datatagr** function `validate_datatagr()` based on ongoing developments over at **linelist**.

Specifically, it incorporates the changes proposed in https://github.com/epiverse-trace/linelist/pull/146. This PR ensures we do not diverge while development on linelist continues before it integrates datatagr for the core tagging functionality.
